### PR TITLE
Don't fail if the match function throws a syntax error

### DIFF
--- a/ssh-search-provider@gnome-shell-extensions.brot.github.com/extension.js
+++ b/ssh-search-provider@gnome-shell-extensions.brot.github.com/extension.js
@@ -96,10 +96,15 @@ SshSearchProvider.prototype = {
         let searchResults = [];
         for (var i=0; i<this._hostnames.length; i++) {
             for (var j=0; j<terms.length; j++) {
-                if (this._hostnames[i].match(terms[j])) {
-                    searchResults.push({
-                                'host': this._hostnames[i]
-                    });
+                try {
+                    if (this._hostnames[i].match(terms[j])) {
+                        searchResults.push({
+                            'host': this._hostnames[i]
+                        });
+                    }
+                }
+                catch(ex) {
+                    continue;
                 }
             }
         }


### PR DESCRIPTION
When typing brackets in the search field, this extension breaks
and other search providers are not run

For example mine: https://github.com/eonpatapon/gnome-shell-extension-calc ;)
